### PR TITLE
Enable setting `Command` environment

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,14 +1,16 @@
 use std::env;
 
-use pete::{Ptracer, Restart};
+use pete::{Command, Ptracer, Restart};
 
 
 fn main() -> anyhow::Result<()> {
     let argv = env::args().skip(1).collect();
+    let cmd = Command::new(argv)?;
+
     let mut ptracer = Ptracer::new();
 
     // Tracee is in pre-exec ptrace-stop.
-    let tracee = ptracer.spawn(argv)?;
+    let tracee = ptracer.spawn(cmd)?;
     ptracer.restart(tracee, Restart::Continue)?;
 
     while let Some(tracee) = ptracer.wait()? {

--- a/examples/set_env.rs
+++ b/examples/set_env.rs
@@ -1,0 +1,27 @@
+use std::env;
+
+use pete::{Command, Ptracer, Restart};
+
+
+fn main() -> anyhow::Result<()> {
+    let argv = env::args().skip(1).collect();
+    let mut cmd = Command::new(argv)?;
+    cmd.env().set("HELLO", "world")?;
+
+    let mut ptracer = Ptracer::new();
+
+    // Tracee is in pre-exec ptrace-stop.
+    let tracee = ptracer.spawn(cmd)?;
+    ptracer.restart(tracee, Restart::Continue)?;
+
+    while let Some(tracee) = ptracer.wait()? {
+        let regs = tracee.registers()?;
+        let pc = regs.rip as u64;
+
+        println!("{:>16x}: {:?}", pc, tracee.stop);
+
+        ptracer.restart(tracee, Restart::Continue)?;
+    }
+
+    Ok(())
+}

--- a/examples/syscalls.rs
+++ b/examples/syscalls.rs
@@ -1,17 +1,19 @@
 use std::collections::BTreeMap;
 use std::env;
 
-use pete::{Ptracer, Restart, Stop};
+use pete::{Command, Ptracer, Restart, Stop};
 
 
 fn main() -> anyhow::Result<()> {
     let syscalls = load_syscalls();
 
     let argv = env::args().skip(1).collect();
+    let cmd = Command::new(argv)?;
+
     let mut ptracer = Ptracer::new();
 
     // Tracee is in pre-exec ptrace-stop.
-    let tracee = ptracer.spawn(argv)?;
+    let tracee = ptracer.spawn(cmd)?;
     ptracer.restart(tracee, Restart::Syscall)?;
 
     while let Ok(Some(tracee)) = ptracer.wait() {

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,4 +1,6 @@
-use std::ffi::{CString, NulError};
+use std::collections::HashMap;
+use std::ffi::{CString, NulError, OsString};
+use std::os::raw::c_char;
 
 use nix::{
     sys::{signal::{raise, Signal}, ptrace},
@@ -18,6 +20,11 @@ pub struct Command {
     ///
     /// Defaults to `true`.
     trace_me: bool,
+
+    /// Environment to use for the child process.
+    ///
+    /// Inherits the parent's environment by default.
+    env: OsEnv,
 }
 
 impl Command {
@@ -35,7 +42,18 @@ impl Command {
             .collect();
         let argv = argv?;
 
-        Ok(Self { argv, trace_me: true })
+        let env = OsEnv::new()?;
+
+        Ok(Self { argv, env, trace_me: true })
+    }
+
+    pub fn env<K, V>(&mut self, key: K, val: V) -> Result<&mut Command, NulError>
+    where
+        K: Into<OsString>,
+        V: Into<OsString>,
+    {
+        self.env.set(key, val)?;
+        Ok(self)
     }
 
     /// Set the value of the `trace_me` flag.
@@ -49,8 +67,10 @@ impl Command {
     /// If `self.trace_me`, the child process will set itself as a tracee of the parent,
     /// then raise `SIGSTOP` so the parent can resume and observe it without a race.
     pub fn fork_exec(self) -> Result<Pid, Error> {
-        // Heap-allocates, must occur pre-fork.
-        let argv = self.argv();
+        // These calls heap-allocate, and must occur pre-fork.
+        let argv = NullTerminatedPointerArray::new(&self.argv);
+        let env = self.env.as_vec();
+        let env = NullTerminatedPointerArray::new(&env);
 
         match fork()? {
             ForkResult::Child => {
@@ -68,7 +88,7 @@ impl Command {
                 // Use unsafe `libc::execv`, because the `nix` wrapper heap- allocates a
                 // `Vec` internally, which is not async-signal-safe.
                 unsafe {
-                    if 0 != libc::execv(argv[0], argv.as_ptr()) {
+                    if 0 != libc::execve(&*argv[0], argv.as_ptr(), env.as_ptr()) {
                         panic!("Unable to exec tracee");
                     }
                 }
@@ -80,15 +100,82 @@ impl Command {
             },
         }
     }
+}
 
-    // Construct NUL-terminated arguments for `execv`. We heap-allocate to return a `Vec`,
-    // and so must do this before calling `fork()`.
-    fn argv(&self) -> Vec<*const libc::c_char> {
-        let mut argv: Vec<_> = self.argv
+#[derive(Clone, Debug)]
+struct OsEnv {
+    kvs: HashMap<OsString, CString>,
+}
+
+impl OsEnv {
+    pub fn new() -> Result<Self, NulError> {
+        let kvs = HashMap::new();
+        let mut env = Self { kvs };
+
+        // Inherit parent environment by default.
+        for (key, val) in std::env::vars_os() {
+            OsEnv::set(&mut env, key, val)?;
+        }
+
+        Ok(env)
+    }
+
+    pub fn set<K, V>(&mut self, key: K, val: V) -> Result<(), NulError>
+    where
+        K: Into<OsString>,
+        V: Into<OsString>,
+    {
+        use std::os::unix::ffi::OsStrExt;
+
+        let key = key.into();
+        let val = val.into();
+
+        // Create an `OsString` of the form `${key}=${value}`.
+        let mut kv = OsString::new();
+        kv.push(&key);
+        kv.push("=");
+        kv.push(val);
+
+        // NUL-terminate the KV string.
+        let kv = CString::new(kv.as_bytes())?;
+
+        self.kvs.insert(key, kv);
+
+        Ok(())
+    }
+
+    pub fn as_vec(&self) -> Vec<CString> {
+        self.kvs.values().cloned().collect()
+    }
+}
+
+// View of a slice of `CString` values, as a null-terminated array of pointers to
+// `c_char`. For passing args to `execve()`.
+struct NullTerminatedPointerArray<'a> {
+    // Owned pointer array which must always be NULL-terminated.
+    array: Vec<*const libc::c_char>,
+
+    // Borrow of pointed-to `CString` data. Pointers in `array` are valid only
+    // while we have this borrow.
+    _data: &'a [CString],
+}
+
+impl<'a> NullTerminatedPointerArray<'a> {
+    pub fn new(data: &'a [CString]) -> Self {
+        let mut array: Vec<_> = data
             .iter()
             .map(|s| s.as_ptr())
             .collect();
-        argv.push(std::ptr::null());
-        argv
+        array.push(std::ptr::null());
+
+        Self { array, _data: data }
+    }
+}
+
+impl<'a> std::ops::Deref for NullTerminatedPointerArray<'a> {
+    type Target = [*const c_char];
+
+    fn deref(&self) -> &Self::Target {
+        &self.array
     }
 }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::ffi::{CString, NulError, OsString};
+use std::ffi::{CString, NulError, OsStr, OsString};
 use std::os::raw::c_char;
 
 use nix::{
@@ -117,24 +117,24 @@ impl OsEnv {
 
     pub fn set<K, V>(&mut self, key: K, val: V) -> Result<(), NulError>
     where
-        K: Into<OsString>,
-        V: Into<OsString>,
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
     {
         use std::os::unix::ffi::OsStrExt;
 
-        let key = key.into();
-        let val = val.into();
+        let key = key.as_ref();
+        let val = val.as_ref();
 
         // Create an `OsString` of the form `${key}=${value}`.
         let mut kv = OsString::new();
-        kv.push(&key);
+        kv.push(key);
         kv.push("=");
         kv.push(val);
 
         // NUL-terminate the KV string.
         let kv = CString::new(kv.as_bytes())?;
 
-        self.kvs.insert(key, kv);
+        self.kvs.insert(key.to_owned(), kv);
 
         Ok(())
     }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -47,13 +47,8 @@ impl Command {
         Ok(Self { argv, env, trace_me: true })
     }
 
-    pub fn env<K, V>(&mut self, key: K, val: V) -> Result<&mut Command, NulError>
-    where
-        K: Into<OsString>,
-        V: Into<OsString>,
-    {
-        self.env.set(key, val)?;
-        Ok(self)
+    pub fn env(&mut self) -> &mut OsEnv {
+        &mut self.env
     }
 
     /// Set the value of the `trace_me` flag.
@@ -103,7 +98,7 @@ impl Command {
 }
 
 #[derive(Clone, Debug)]
-struct OsEnv {
+pub struct OsEnv {
     kvs: HashMap<OsString, CString>,
 }
 

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -139,6 +139,10 @@ impl OsEnv {
         Ok(())
     }
 
+    pub fn clear(&mut self) {
+        self.kvs.clear();
+    }
+
     pub fn as_vec(&self) -> Vec<CString> {
         self.kvs.values().cloned().collect()
     }

--- a/src/ptracer.rs
+++ b/src/ptracer.rs
@@ -197,12 +197,9 @@ impl Ptracer {
         })
     }
 
-    pub fn spawn(&mut self, argv: Vec<String>) -> Result<Tracee> {
+    pub fn spawn(&mut self, cmd: Command) -> Result<Tracee> {
         // Fork, request TRACEME, raise a pre-exec SIGSTOP.
-        let pid = Command::new(argv)
-            .expect("argv strings should be NUL-free")
-            .trace_me(true)
-            .fork_exec()?;
+        let pid = cmd.trace_me(true).fork_exec()?;
 
         self.set_tracee_state(pid, State::Attaching);
 


### PR DESCRIPTION
- Allow setting tracee environment in `Command`
- Exec with `execve()`
- Breaking change: `spawn()` now accepts a `Command` instead of an arg vector

Closes #4.