### PR TITLE
Have the vfork handler register its new child with the ptracer

### DIFF
--- a/src/ptracer.rs
+++ b/src/ptracer.rs
@@ -343,6 +343,7 @@ impl Ptracer {
                     },
                     PTRACE_EVENT_VFORK => {
                         let new_pid = Pid::from_raw(ptrace::getevent(pid)? as u32 as i32);
+                        self.set_tracee_state(new_pid, State::Attaching);
                         let stop = Stop::Vfork(pid, new_pid);
 
                         Tracee::new(pid, sig, stop)


### PR DESCRIPTION
This mirrors the implementation in normal fork and clone, and seems to prevent a
panic around line 421 of ptracer.rs.

Fixes #7