### PR TITLE
Upgrade to new versions for crates lib, nix, thiserror.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ repository = "https://github.com/ranweiler/pete"
 description = "A friendly wrapper around ptrace(2)"
 
 [dependencies]
-libc = "0.2.66"
-nix = "0.17.0"
-thiserror = "1.0.11"
+libc = "0.2.80"
+nix = "0.19.0"
+thiserror = "1.0.22"
 
 [dev-dependencies]
 anyhow = "1.0.31"

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -67,7 +67,7 @@ impl Command {
         let env = self.env.as_vec();
         let env = NullTerminatedPointerArray::new(&env);
 
-        match fork()? {
+        match unsafe {fork()?} {
             ForkResult::Child => {
                 // If any post-fork call fails, `panic`, since `?` may call `malloc`
                 // via `Into`, which is not async-signal-safe.

--- a/src/ptracer.rs
+++ b/src/ptracer.rs
@@ -226,17 +226,13 @@ impl Ptracer {
         r
     }
 
-    pub fn add_spawned(&mut self, pid: Pid) -> Result<Tracee> {
+    pub fn add_spawned(&mut self, pid: Pid) -> Result<()> {
         self.mark_tracee(pid);
 
-        // Wait on initial attach stop, which in this case is a synthetic SIGSTOP
-        // raised after forking and requesting TRACEME.
-        let mut tracee = self.wait().map(|t| t.unwrap())?;
-
         // Set global tracing options on root tracee.
-        tracee.set_options(self.options)?;
+        Tracee::new(pid, None, Stop::AttachStop(pid)).set_options(self.options)?;
 
-        Ok(tracee)
+        Ok(())
     }
 
     /// Wait for some running tracee process to stop.

--- a/src/ptracer.rs
+++ b/src/ptracer.rs
@@ -226,6 +226,19 @@ impl Ptracer {
         r
     }
 
+    pub fn add_spawned(&mut self, pid: Pid) -> Result<Tracee> {
+        self.mark_tracee(pid);
+
+        // Wait on initial attach stop, which in this case is a synthetic SIGSTOP
+        // raised after forking and requesting TRACEME.
+        let mut tracee = self.wait().map(|t| t.unwrap())?;
+
+        // Set global tracing options on root tracee.
+        tracee.set_options(self.options)?;
+
+        Ok(tracee)
+    }
+
     /// Wait for some running tracee process to stop.
     pub fn wait(&mut self) -> Result<Option<Tracee>> {
         use Signal::*;

--- a/src/ptracer.rs
+++ b/src/ptracer.rs
@@ -226,13 +226,14 @@ impl Ptracer {
         r
     }
 
-    pub fn add_spawned(&mut self, pid: Pid) -> Result<()> {
+    pub fn add_spawned(&mut self, pid: Pid) -> Result<Tracee> {
         self.mark_tracee(pid);
 
         // Set global tracing options on root tracee.
-        Tracee::new(pid, None, Stop::AttachStop(pid)).set_options(self.options)?;
+        let mut tracee = Tracee::new(pid, None, Stop::AttachStop(pid));
+        tracee.set_options(self.options)?;
 
-        Ok(())
+        Ok(tracee)
     }
 
     /// Wait for some running tracee process to stop.

--- a/src/ptracer.rs
+++ b/src/ptracer.rs
@@ -228,6 +228,7 @@ impl Ptracer {
 
     pub fn add_spawned(&mut self, pid: Pid) -> Result<Tracee> {
         self.mark_tracee(pid);
+        self.set_tracee_state(pid, State::Traced);
 
         // Set global tracing options on root tracee.
         let mut tracee = Tracee::new(pid, None, Stop::AttachStop(pid));

--- a/src/ptracer.rs
+++ b/src/ptracer.rs
@@ -228,10 +228,8 @@ impl Ptracer {
 
     pub fn add_spawned(&mut self, pid: Pid) -> Result<Tracee> {
         self.mark_tracee(pid);
-        self.set_tracee_state(pid, State::Traced);
-
-        // Set global tracing options on root tracee.
-        let mut tracee = Tracee::new(pid, Some(Signal::SIGTRAP), Stop::AttachStop(pid));
+        self.set_tracee_state(pid, State::Syscalling);
+        let mut tracee = Tracee::new(pid, None, Stop::AttachStop(pid));
         tracee.set_options(self.options)?;
 
         Ok(tracee)

--- a/src/ptracer.rs
+++ b/src/ptracer.rs
@@ -231,7 +231,7 @@ impl Ptracer {
         self.set_tracee_state(pid, State::Traced);
 
         // Set global tracing options on root tracee.
-        let mut tracee = Tracee::new(pid, None, Stop::AttachStop(pid));
+        let mut tracee = Tracee::new(pid, Some(Signal::SIGTRAP), Stop::AttachStop(pid));
         tracee.set_options(self.options)?;
 
         Ok(tracee)


### PR DESCRIPTION
Change: nix::unistd::fork-function is now unsafe, so has been wrapped by unsafe block

I experienced difficulties because version difference of nix crate: 0.17 for pete, 0.19 native import. I could not use the nix::unistd::pid for pete and therefore had to instanciate the pid twice. With the same version it works well.

Fixes #10 