### PR TITLE
Update examples

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use pete::{Command, Ptracer, Restart};
+use pete::{Command, Ptracer, Restart, Tracee};
 
 
 fn main() -> anyhow::Result<()> {
@@ -17,7 +17,8 @@ fn main() -> anyhow::Result<()> {
         let regs = tracee.registers()?;
         let pc = regs.rip as u64;
 
-        println!("{:>16x}: {:?}", pc, tracee.stop);
+        let Tracee { pid, stop, .. } = tracee;
+        println!("pid={}, pc={:x}: {:?}", pid, pc, stop);
 
         ptracer.restart(tracee, Restart::Continue)?;
     }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -18,7 +18,7 @@ fn main() -> anyhow::Result<()> {
         let pc = regs.rip as u64;
 
         let Tracee { pid, stop, .. } = tracee;
-        println!("pid={}, pc={:x}: {:?}", pid, pc, stop);
+        println!("pid = {}, pc = {:x}: {:?}", pid, pc, stop);
 
         ptracer.restart(tracee, Restart::Continue)?;
     }

--- a/examples/set_env.rs
+++ b/examples/set_env.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use pete::{Command, Ptracer, Restart};
+use pete::{Command, Ptracer, Restart, Tracee};
 
 
 fn main() -> anyhow::Result<()> {
@@ -18,7 +18,8 @@ fn main() -> anyhow::Result<()> {
         let regs = tracee.registers()?;
         let pc = regs.rip as u64;
 
-        println!("{:>16x}: {:?}", pc, tracee.stop);
+        let Tracee { pid, stop, .. } = tracee;
+        println!("pid = {}, pc = {:x}: {:?}", pid, pc, stop);
 
         ptracer.restart(tracee, Restart::Continue)?;
     }

--- a/examples/syscalls.rs
+++ b/examples/syscalls.rs
@@ -24,7 +24,10 @@ fn main() -> anyhow::Result<()> {
             Stop::SyscallEnterStop(..) |
             Stop::SyscallExitStop(..)=> {
                 let rax = regs.orig_rax;
-                let syscall = syscalls.get(&rax).unwrap();
+                let syscall = syscalls
+                    .get(&rax)
+                    .cloned()
+                    .unwrap_or_else(|| format!("unknown (rax = 0x{:x})", rax));
 
                 println!("{:>16x}: [{}], {:?}", pc, syscall, tracee.stop);
             },

--- a/examples/syscalls.rs
+++ b/examples/syscalls.rs
@@ -16,7 +16,7 @@ fn main() -> anyhow::Result<()> {
     let tracee = ptracer.spawn(cmd)?;
     ptracer.restart(tracee, Restart::Syscall)?;
 
-    while let Ok(Some(tracee)) = ptracer.wait() {
+    while let Some(tracee) = ptracer.wait()? {
         let regs = tracee.registers()?;
         let pc = regs.rip as u64;
 

--- a/examples/syscalls.rs
+++ b/examples/syscalls.rs
@@ -54,5 +54,8 @@ fn load_syscalls() -> BTreeMap<u64, String> {
         syscalls.insert(callno, name);
     }
 
+    // Work around in-band communication in impl of `rt_sigreturn()`.
+    syscalls.insert(-1i64 as u64, "rt_sigreturn".into());
+
     syscalls
 }

--- a/examples/syscalls.rs
+++ b/examples/syscalls.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::env;
 
-use pete::{Command, Ptracer, Restart, Stop};
+use pete::{Command, Ptracer, Restart, Stop, Tracee};
 
 
 fn main() -> anyhow::Result<()> {
@@ -29,10 +29,12 @@ fn main() -> anyhow::Result<()> {
                     .cloned()
                     .unwrap_or_else(|| format!("unknown (rax = 0x{:x})", rax));
 
-                println!("{:>16x}: [{}], {:?}", pc, syscall, tracee.stop);
+                let Tracee { pid, stop, .. } = tracee;
+                println!("pid = {}, pc = {:x}: [{}], {:?}", pid, pc, syscall, stop);
             },
             _ => {
-                println!("{:>16x}: {:?}", pc, tracee.stop);
+                let Tracee { pid, stop, .. } = tracee;
+                println!("pid = {}, pc = {:x}: {:?}", pid, pc, stop);
             },
         }
 


### PR DESCRIPTION
- Consistently bail on `wait()` errors
- Handle corner case in syscall-exit-stop from `rt_sigreturn`
- Include pid in log output