### PR TITLE
Revisit errors, remove all panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Rename and expand `Error` variants, replace internal panics with `Error::Internal` returns
 - `Ptracer::spawn()` now takes a `std::process::Command`, returns `Child` instead of `Tracee` ([#21](https://github.com/ranweiler/pete/pull/21))
 - Remove `cmd` module and custom `Command` struct
 - Updated `nix` dependency to 0.19.0

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,9 +13,6 @@ pub enum Error {
         source: nix::Error,
     },
 
-    #[error("Error waiting on tracees")]
-    Wait { source: nix::Error },
-
     #[error("Could not restart tracee = {pid} with mode = {mode:?}")]
     Restart { pid: Pid, mode: Restart, source: nix::Error },
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,8 +20,11 @@ pub enum Error {
     Restart { pid: Pid, mode: Restart, source: nix::Error },
 
     #[error("Input/output error")]
-    InputOutput(#[from] io::Error),
+    IO(#[from] io::Error),
 
-    #[error("Unexpected internal error")]
-    Internal(#[from] nix::Error),
+    #[error("OS error")]
+    OS(#[from] nix::Error),
+
+    #[error("Internal error: please open an issue at https://github.com/ranweiler/pete/issues")]
+    Internal,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,3 +25,9 @@ pub enum Error {
     #[error("Internal error: please open an issue at https://github.com/ranweiler/pete/issues")]
     Internal,
 }
+
+macro_rules! internal_error {
+    () => {
+        return Err($crate::error::Error::Internal)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
+#[macro_use]
 pub mod error;
+
 pub mod ptracer;
 
 pub use error::Error;

--- a/src/ptracer.rs
+++ b/src/ptracer.rs
@@ -405,7 +405,7 @@ impl Ptracer {
                             Some(state) if *state == State::Attaching => {
                                 *state = State::Syscalling;
                             },
-                            _ => unreachable!()
+                            _ => internal_error!(),
                         }
 
                         Tracee::new(pid, sig, stop)
@@ -455,7 +455,7 @@ impl Ptracer {
                                 // A tracee in this state is waiting for a `SIGSTOP`, which is an
                                 // artifact of `PTRACE_ATTACH`. The next wait status will thus be
                                 // either a `SIGSTOP`, `SIGKILL`, or a `PTRACE_EVENT_EXIT`.
-                                unreachable!()
+                                internal_error!()
                             },
                             State::Spawned => {
                                 // We only set the tracee state to `Spawned` after a successful call
@@ -465,13 +465,13 @@ impl Ptracer {
                                 // can only self-attach with default options, the `execve()` will be
                                 // seen as a `SIGTRAP` signal-delivery-stop, not a syscall-stop or
                                 // ptrace-event-stop, and so we can never reach this case.
-                                unreachable!()
+                                internal_error!()
                             },
                         }
                     },
                     None => {
                         // Assumes any pid we are tracing is also indexed in `self.tracees`.
-                        unreachable!()
+                        internal_error!()
                     },
                 };
 

--- a/src/ptracer.rs
+++ b/src/ptracer.rs
@@ -480,7 +480,7 @@ impl Ptracer {
             // Assume `!WNOHANG`, `!WCONTINUED`.
             WaitStatus::Continued(_) |
             WaitStatus::StillAlive =>
-                unreachable!(),
+                internal_error!(),
         };
 
         Ok(Some(tracee))

--- a/src/ptracer.rs
+++ b/src/ptracer.rs
@@ -534,7 +534,7 @@ impl ExitType {
             use std::convert::TryFrom;
 
             let core_dump = (status & (1 << 7)) >> 7;
-            let signal = Signal::try_from(sig_no as i32).unwrap();
+            let signal = Signal::try_from(sig_no as i32)?;
             let core_dump = core_dump > 0;
 
             ExitType::Signaled(signal, core_dump)


### PR DESCRIPTION
- Revisit `Error` enum
- Use `Error::Internal` for logic errors, unreachable code
- Remove all panics in `ptracer`

Closes #5.