### PR TITLE
Add context to `Error::Internal`, fix seccomp event bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Add context to `Error::Internal` ([#25](https://github.com/ranweiler/pete/pull/25))
 - Rename and expand `Error` variants, replace internal panics with `Error::Internal` returns
 - `Ptracer::spawn()` now takes a `std::process::Command`, returns `Child` instead of `Tracee` ([#21](https://github.com/ranweiler/pete/pull/21))
 - Remove `cmd` module and custom `Command` struct
 - Updated `nix` dependency to 0.19.0
+
+### Fixed
+
+- Don't treat seccomp event-stops as internal errors when tracees have non-`Attaching` state ([#25](https://github.com/ranweiler/pete/pull/25))
 
 ## [0.3.1] - 2020-11-14
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,12 +22,12 @@ pub enum Error {
     #[error("OS error")]
     OS(#[from] nix::Error),
 
-    #[error("Internal error: please open an issue at https://github.com/ranweiler/pete/issues")]
-    Internal,
+    #[error("Internal error: {0}. Please open an issue at https://github.com/ranweiler/pete/issues")]
+    Internal(String),
 }
 
 macro_rules! internal_error {
-    () => {
-        return Err($crate::error::Error::Internal)
+    ($ctx: expr) => {
+        return Err($crate::error::Error::Internal($ctx.into()));
     }
 }


### PR DESCRIPTION
- Add a `String` context to `Error::Internal`
- Remove an over-zealous bail in the `seccomp` event-stop handler