### PR TITLE
Update `nix` to 0.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+
+- Update `nix` lower bound to 0.21.0
+- Minimum supported `rustc` version is now 1.41.0, via `nix`
+
+### Fixed
+
 ## [0.4.0] - 2020-11-16
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "A friendly wrapper around ptrace(2)"
 
 [dependencies]
 libc = "0.2.66"
-nix = "0.19.0"
+nix = "0.21.0"
 thiserror = "1.0.11"
 
 [dev-dependencies]


### PR DESCRIPTION
**Note:** this update raises our minimum supported `rustc` to 1.41.0.