### PR TITLE
Add syscall tracepoint test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  build:
-    name: build (${{ matrix.rust }})
+  ci:
+    name: ci (${{ matrix.rust }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -18,7 +18,9 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --examples
+      - name: build (debug, examples)
+        run: cargo build --examples
+      - name: "build `syscalls` example (release)"
+        run: cargo build --release --example syscalls
+      - name: "integration test (syscalls)"
+        run: ./script/syscall-tracepoint-test ./target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,5 @@ thiserror = "1.0.11"
 
 [dev-dependencies]
 anyhow = "1.0.31"
+lazy_static = "1.4.0"
 structopt = "0.3.21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ thiserror = "1.0.11"
 
 [dev-dependencies]
 anyhow = "1.0.31"
+structopt = "0.3.21"

--- a/examples/syscalls.rs
+++ b/examples/syscalls.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use anyhow::Result;
 use pete::{Ptracer, Restart, Stop, Tracee};
@@ -11,6 +11,9 @@ struct Opt {
     #[structopt(short, long)]
     tsv: bool,
 
+    #[structopt(short, long)]
+    quiet: bool,
+
     #[structopt(min_values = 1)]
     argv: Vec<String>,
 }
@@ -18,9 +21,16 @@ struct Opt {
 fn main() -> Result<()> {
     let opt = Opt::from_args();
     let argv: Vec<String> = opt.argv;
+
     let mut cmd = Command::new(&argv[0]);
+
     if let Some(args) = argv.get(1..) {
         cmd.args(args);
+    }
+
+    if opt.quiet {
+        cmd.stdout(Stdio::null());
+        cmd.stderr(Stdio::null());
     }
 
     let mut ptracer = Ptracer::new();

--- a/examples/syscalls.rs
+++ b/examples/syscalls.rs
@@ -1,16 +1,24 @@
 use std::collections::BTreeMap;
-use std::env;
 use std::process::Command;
 
 use pete::{Ptracer, Restart, Stop, Tracee};
+use structopt::StructOpt;
 
+#[derive(StructOpt, Debug)]
+struct Opt {
+    #[structopt(min_values = 1)]
+    argv: Vec<String>,
+}
 
 fn main() -> anyhow::Result<()> {
     let syscalls = load_syscalls();
 
-    let argv: Vec<String> = env::args().skip(1).collect();
+    let opt = Opt::from_args();
+    let argv: Vec<String> = opt.argv;
     let mut cmd = Command::new(&argv[0]);
-    cmd.args(&argv[1..]);
+    if let Some(args) = argv.get(1..) {
+        cmd.args(args);
+    }
 
     let mut ptracer = Ptracer::new();
     let _child = ptracer.spawn(cmd)?;

--- a/script/parse_perf_trace.py
+++ b/script/parse_perf_trace.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+import re
+import sys
+
+
+def main():
+    for line in sys.stdin:
+        m = parse_line(line.strip())
+
+        if m:
+            pid, stop_type, syscallno = m
+            print(f"{pid}\t{stop_type}\t{syscallno}")
+
+
+PATTERN = re.compile("(\d+) .* raw_syscalls:sys_(enter|exit): NR (\d+)")
+
+
+def parse_line(line):
+    m = PATTERN.search(line)
+
+    if not m:
+        return None
+
+    # PID, enter/exit, syscall number.
+    return m.group(1, 2, 3)
+
+
+if __name__ == "__main__":
+    main()

--- a/script/syscall-tracepoint-test
+++ b/script/syscall-tracepoint-test
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -ex -o pipefail
+
+SCRIPT_DIR=$(readlink -f $(dirname "$0"))
+BUILD_ROOT=$(readlink -f $1)
+SYSCALL_EX="${BUILD_ROOT}/release/examples/syscalls"
+
+do_test() {
+    # Spawn and trace a `pete` example tracer that emits syscalls as TSV. Pipe the
+    # tracee's output to `pete.tsv` while also recording raw syscall enter and exit
+    # tracepoints.
+    sudo perf record \
+         --inherit \
+         -o perf.data \
+         -e 'raw_syscalls:sys_enter' \
+         -e 'raw_syscalls:sys_exit' \
+         -- $SYSCALL_EX -q -t echo hello > pete.tsv
+
+    # Convert the binary perf data to text. This text will be formatted as as specified in
+    # the files `/sys/kernel/debug/tracing/events/raw_syscalls/sys_{enter,exit}/format`.
+    sudo perf script -i perf.data > perf.log
+
+    # Filter out perf events from the `pete` tracer.
+    grep -v '^[[:space:]]*syscalls' perf.log > perf-target.log
+
+    # Convert the text tracepoint data into TSV that matches the `pete` example's output.
+    ${SCRIPT_DIR}/parse_perf_trace.py < perf-target.log > perf.tsv
+
+    # Ensure at least one file is nonempty, so we don't get a spurious pass by comparing
+    # two empty files.
+    if (( $(du -b perf.tsv | cut -f1) == 0 )); then
+        echo 'test error: `perf.tsv` is empty'
+        exit 1
+    fi
+
+    diff -q perf.tsv pete.tsv
+}
+
+TMP_DIR=$(mktemp -d)
+pushd $TMP_DIR
+
+do_test
+
+popd
+rm -rf $TMP_DIR


### PR DESCRIPTION
- Update the `syscalls` example with tracee-quieting and TSV output options (to support testing)
- Add scripts for testing syscall tracing by comparing against kernel tracepoint events
- Run integration test in CI task