### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 A friendly wrapper around the Linux `ptrace(2)` syscall.
 
+## Requirements
+
+The minimum supported OS and compiler versions are:
+
+- Linux 4.8
+- rustc 1.41.0
+
+Support for earlier Linux versions is possible, but would require additional effort.
+
 ## Summary
 
 The `ptrace(2)` interface entails interpreting a series of `wait(2)` statuses. The context used to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,5 +3,8 @@ pub mod error;
 
 pub mod ptracer;
 
+#[doc(inline)]
 pub use error::Error;
+
+#[doc(inline)]
 pub use ptracer::{Pid, Ptracer, Registers, Restart, Siginfo, Signal, Stop, Tracee};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,18 @@
+//! A friendly wrapper around the Linux `ptrace(2)` system call.
+//!
+//! The `ptrace(2)` interface entails interpreting a series of `wait(2)` statuses. The context used
+//! to interpret a status includes the attach options set on each tracee, previously-seen stops,
+//! recent `ptrace` requests, and in some cases, extra event data that must be queried using
+//! additional `ptrace` calls.
+//!
+//! Pete is meant to instead permit reasoning directly about ptrace-stops, as described in the
+//! manual. We hide the lowest-level contextual bookkeeping required to disambiguate
+//! [ptrace-stops](ptracer::Stop). Whenever we can, we avoid extraneous ptrace calls, deferring to
+//! downstream tracers implemented on top of the library. For example, Pete can distinguish a
+//! syscall-enter-stop and syscall-exit-stop, but does not _automatically_ query register state to
+//! identify the specific syscall.
+
+
 #[macro_use]
 pub mod error;
 

--- a/src/ptracer.rs
+++ b/src/ptracer.rs
@@ -15,14 +15,24 @@ use crate::error::{Error, Result};
 
 pub use nix::unistd::Pid;
 pub use nix::sys::ptrace::Options;
+
+/// POSIX signal.
 pub use nix::sys::signal::Signal;
 
+/// Register state of a tracee.
 pub type Registers = libc::user_regs_struct;
+
+/// Extra signal info, such as its cause.
 pub type Siginfo = libc::siginfo_t;
 
 const WALL: Option<WaitPidFlag> = Some(WaitPidFlag::__WALL);
 
-/// Various ptrace-stops.
+/// A _ptrace-stop_, a tracee state in which it is stopped and ready to accept ptrace
+/// commands.
+///
+/// These ptrace-stops may carry data obtained via additional (internal) ptrace requests
+/// to `PTRACE_GETEVENTMSG`. Requests to `PTRACE_GETSIGINFO` may be made to disambiguate
+/// stops.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Stop {
     AttachStop(Pid),
@@ -48,7 +58,9 @@ pub enum Stop {
     Seccomp(u16),
 }
 
-/// Ptrace restart requests.
+/// Restart requests, which resume stopped tracees.
+///
+/// The restart mode determines the possible subsequent stops of the restarted tracee.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Restart {
     Step,
@@ -56,12 +68,10 @@ pub enum Restart {
     Syscall,
 }
 
-/// Tracee in ptrace-stop, with an optional pending signal.
+/// Tracee task in ptrace-stop, with an optional pending signal.
 ///
-/// Describes how the stopped tracee would continue if it weren't traced, and thus how to
-/// restart it to resume normal execution.
-///
-/// The underlying tracee is not guaranteed to exist.
+/// **Warning:** the underlying tracee is not guaranteed to exist, and
+/// operations on it may fail between calls to [`Ptracer::wait()`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Tracee {
     pub pid: Pid,
@@ -163,7 +173,12 @@ enum State {
     Syscalling,
 }
 
-/// Tracer for a (possibly multi-threaded) Linux process.
+/// Tracer for a Linux process.
+///
+/// By default, [spawning](Ptracer::spawn()) a child tracee will follow calls to `fork()`,
+/// `clone()`, and `exec()`, tracing any child tasks (both threads and processes).
+///
+/// This can be configured for any stopped tracee via [`Tracee::set_options()`].
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Ptracer {
     /// Ptrace options that will be applied to tracees, by default.
@@ -201,6 +216,10 @@ impl Ptracer {
         })
     }
 
+    /// Spawn `cmd` for tracing.
+    ///
+    /// The command will be configured to requrest `PTRACE_TRACEME` after `fork()` and
+    /// pre-`exec()`. The caller will use this to avoid races and missed events.
     pub fn spawn(&mut self, mut cmd: Command) -> Result<Child> {
         // On fork, request `PTRACE_TRACEME`.
         unsafe {
@@ -218,10 +237,10 @@ impl Ptracer {
         Ok(child)
     }
 
-    /// Attach to a running tracee. This will deliver a SIGSTOP.
+    /// Attach to a running tracee. This will deliver a `SIGSTOP`.
     ///
-    /// Warning: the tracee may not be considered stopped until it has been seen
-    /// to stop via `wait()`.
+    /// **Warning:** the tracee may not be considered stopped until it has been seen to
+    /// stop via `wait()`.
     pub fn attach(&mut self, pid: Pid) -> Result<()> {
         let r = ptrace::attach(pid);
         let r = r.map_err(|source| Error::Attach { pid, source });
@@ -232,6 +251,8 @@ impl Ptracer {
     }
 
     /// Wait for some running tracee process to stop.
+    ///
+    /// If there are no tracees to wait on, returns `None`.
     pub fn wait(&mut self) -> Result<Option<Tracee>> {
         use Signal::*;
 

--- a/src/ptracer.rs
+++ b/src/ptracer.rs
@@ -68,6 +68,7 @@ pub struct Tracee {
     pub pending: Option<Signal>,
     pub stop: Stop,
 
+    #[doc(hidden)]
     pub _not_send: PhantomData<*const ()>,
 }
 


### PR DESCRIPTION
- Add top-level module docs
- Document most public types and functions
- Fix display of re-exports
- Document minimum supported OS and compiler versions

Closes #18.