### PR TITLE
Add user-facing detection of stopped tracee death

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
           override: true
       - name: build (debug, examples)
         run: cargo build --examples
+      - name: test (debug)
+        run: cargo test
       - name: "build `syscalls` example (release)"
         run: cargo build --release --example syscalls
       - name: "integration test (syscalls)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [`Error::TraceeDied`] variant, [`Error::tracee_died()`] method to improve error ergonomics
+- `Error::TraceeDied` variant, `Error::tracee_died()` method to improve error ergonomics
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [`Error::TraceeDied`] variant, [`Error::tracee_died()`] method to improve error ergonomics
+
 ### Changed
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,5 @@ thiserror = "1.0.11"
 [dev-dependencies]
 anyhow = "1.0.31"
 lazy_static = "1.4.0"
+ntest = "0.7.3"
 structopt = "0.3.21"

--- a/src/error.rs
+++ b/src/error.rs
@@ -61,6 +61,10 @@ macro_rules! internal_error {
 }
 
 pub(crate) trait ResultExt<T> {
+    /// Maps an `ESRCH` error result to `Error::TraceeDied`.
+    ///
+    /// Should only be called on results of `ptrace()` operations on valid tracees known
+    /// to be in ptrace-stop.
     fn died_if_esrch(self, pid: Pid) -> Result<T>;
 }
 

--- a/tests/tracee_died.rs
+++ b/tests/tracee_died.rs
@@ -1,0 +1,41 @@
+use std::process::Command;
+
+use anyhow::Result;
+use pete::{Error, Ptracer, Restart};
+
+#[test]
+fn test_tracee_died() -> Result<()> {
+    let cmd = Command::new("true");
+
+    let mut tracer = Ptracer::new();
+    let mut child = tracer.spawn(cmd)?;
+
+    let mut died = false;
+
+    while let Some(tracee) = tracer.wait()? {
+        // Kill the stopped tracee, so restart and subsequent ptrace calls fail.
+        child.kill()?;
+
+        if let Err(err) = tracer.restart(tracee, Restart::Continue) {
+            assert!(matches!(err, Error::Restart { .. }));
+            assert!(err.tracee_died());
+
+            let regs = tracee.registers();
+
+            assert!(regs.is_err());
+
+            if let Err(err) = regs {
+                assert!(matches!(err, Error::TraceeDied { .. }));
+                assert!(err.tracee_died());
+            } else {
+                unreachable!();
+            }
+
+            died = true;
+        }
+    }
+
+    assert!(died);
+
+    Ok(())
+}

--- a/tests/tracee_died.rs
+++ b/tests/tracee_died.rs
@@ -4,6 +4,17 @@ use anyhow::Result;
 use ntest::timeout;
 use pete::{Error, Ptracer, Restart};
 
+// Support absence of `matches!(0` in rustc 1.41.0.
+macro_rules! assert_matches {
+    ($expr: expr, $pat: pat) => {
+        if let $pat = $expr {
+            // Pass.
+        } else {
+            panic!("expected `{}` to match `{}`", stringify!($expr), stringify!($pat));
+        }
+    }
+}
+
 #[test]
 #[timeout(100)]
 fn test_tracee_died() -> Result<()> {
@@ -19,7 +30,7 @@ fn test_tracee_died() -> Result<()> {
         child.kill()?;
 
         if let Err(err) = tracer.restart(tracee, Restart::Continue) {
-            assert!(matches!(err, Error::Restart { .. }));
+            assert_matches!(err, Error::Restart { .. });
             assert!(err.tracee_died());
 
             let regs = tracee.registers();
@@ -27,7 +38,7 @@ fn test_tracee_died() -> Result<()> {
             assert!(regs.is_err());
 
             if let Err(err) = regs {
-                assert!(matches!(err, Error::TraceeDied { .. }));
+                assert_matches!(err, Error::TraceeDied { .. });
                 assert!(err.tracee_died());
             } else {
                 unreachable!();

--- a/tests/tracee_died.rs
+++ b/tests/tracee_died.rs
@@ -1,9 +1,11 @@
 use std::process::Command;
 
 use anyhow::Result;
+use ntest::timeout;
 use pete::{Error, Ptracer, Restart};
 
 #[test]
+#[timeout(100)]
 fn test_tracee_died() -> Result<()> {
     let cmd = Command::new("true");
 


### PR DESCRIPTION
Tracees can die while stopped, but the `ptrace()`-level error is ambiguous without context. The tracer has the required context, so we now detect stopped tracee death (when unambiguous), and surface it to users.

- Add variant `Error::TraceeDied`, which is only emitted when a `ptrace()` call fails on a tracee known to be in ptrace-stop
- Add the method `Error::tracee_died()`, which returns `true` if the `Error` variant is `Restart` or `TraceeDied`
- Use a private extension trait to map internal `ptrace()` errors to `Error::TraceeDied`, when appropriate
- Run tests in CI

Closes #39.