### PR TITLE
Remove redundant `Stop` fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Hide accidentally-`pub` marker field `Tracee._not_send`
 - Remove `Error::Restart`, replace only use with `TraceeDied`
+- Remove redundant PIDs from `Stop` variants
 
 ### Fixed
 

--- a/examples/syscalls.rs
+++ b/examples/syscalls.rs
@@ -54,8 +54,8 @@ fn on_stop(tracee: &mut Tracee) -> Result<()> {
     let pc = regs.rip as u64;
 
     match tracee.stop {
-        Stop::SyscallEnterStop(..) |
-        Stop::SyscallExitStop(..) => {
+        Stop::SyscallEnterStop |
+        Stop::SyscallExitStop => {
             let syscallno = regs.orig_rax;
             let syscall = SYSCALL_TABLE
                 .get(&syscallno)
@@ -76,10 +76,10 @@ fn on_stop(tracee: &mut Tracee) -> Result<()> {
 
 fn on_stop_tsv(tracee: &mut Tracee) -> Result<()> {
     match tracee.stop {
-        Stop::SyscallEnterStop(..) => {
+        Stop::SyscallEnterStop => {
             on_syscall_stop_tsv(tracee, true)?;
         }
-        Stop::SyscallExitStop(..)=> {
+        Stop::SyscallExitStop => {
             on_syscall_stop_tsv(tracee, false)?;
         }
         _ => {},


### PR DESCRIPTION
Almost all `Stop` variants have a `Pid`-valued field that identifies the stopped tracee. This is redundant when accessed via the `Tracee`, which we typically expect any `Stop` consumer to have access to. This is also confusing, since we use tuple structs, and there are sometimes multiple PIDs associated with a stop.

Remove the redundant PIDs. Require users to pass either the `Tracee` or tracee PID when needed.

This is a breaking change.