### PR TITLE
Conditionally compile arch-specific features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,24 @@ jobs:
         run: cargo build --release --example syscalls
       - name: "integration test (syscalls)"
         run: ./script/syscall-tracepoint-test ./target
+  cross:
+    name: cross-compile (${{ matrix.rust }}-${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - aarch64-unknown-linux-gnu
+        rust:
+          - stable
+          - 1.41.0
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - name: add target ${{ matrix.rust }}-${{ matrix.target }}
+        run: rustup target add ${{ matrix.target }}
+      - name: check (debug)
+        run: cargo check --target=${{ matrix.target }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Check `target_arch` before using x86-only features
+
 ## [0.5.0] - 2021-06-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Check `target_arch` before using x86-only features
+- Condition `Register`-related definitions, exports on `target_arch`
 
 ## [0.5.0] - 2021-06-21
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,4 +22,8 @@ pub mod ptracer;
 pub use error::Error;
 
 #[doc(inline)]
-pub use ptracer::{Pid, Ptracer, Registers, Restart, Siginfo, Signal, Stop, Tracee};
+pub use ptracer::{Pid, Ptracer, Restart, Siginfo, Signal, Stop, Tracee};
+
+#[cfg(target_arch = "x86_64")]
+#[doc(inline)]
+pub use ptracer::Registers;

--- a/src/ptracer.rs
+++ b/src/ptracer.rs
@@ -22,6 +22,7 @@ pub use nix::sys::ptrace::Options;
 pub use nix::sys::signal::Signal;
 
 /// Register state of a tracee.
+#[cfg(target_arch = "x86_64")]
 pub type Registers = libc::user_regs_struct;
 
 /// Extra signal info, such as its cause.
@@ -110,10 +111,12 @@ impl Tracee {
         Ok(ptrace::setoptions(self.pid, options).died_if_esrch(self.pid)?)
     }
 
+    #[cfg(target_arch = "x86_64")]
     pub fn registers(&self) -> Result<Registers> {
         Ok(ptrace::getregs(self.pid).died_if_esrch(self.pid)?)
     }
 
+    #[cfg(target_arch = "x86_64")]
     pub fn set_registers(&mut self, regs: Registers) -> Result<()> {
         Ok(ptrace::setregs(self.pid, regs).died_if_esrch(self.pid)?)
     }

--- a/tests/tracee_died.rs
+++ b/tests/tracee_died.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use ntest::timeout;
 use pete::{Error, Ptracer, Restart};
 
-// Support absence of `matches!(0` in rustc 1.41.0.
+// Support absence of `matches!()` in rustc 1.41.0.
 macro_rules! assert_matches {
     ($expr: expr, $pat: pat) => {
         if let $pat = $expr {

--- a/tests/tracee_died.rs
+++ b/tests/tracee_died.rs
@@ -15,6 +15,7 @@ macro_rules! assert_matches {
     }
 }
 
+#[cfg(target_arch = "x86_64")]
 #[test]
 #[timeout(100)]
 fn test_tracee_died() -> Result<()> {


### PR DESCRIPTION
- Condition `Register`-related definitions on `target_arch`
- Add CI task to run a cross-compiled `check` for `aarch64-unknown-linux-gnu`

Closes #52.