### PR TITLE
Set `CFLAGS` when building test program

### DIFF
--- a/test-programs/nop/Makefile
+++ b/test-programs/nop/Makefile
@@ -4,7 +4,7 @@ CFLAGS = -fno-pie
 all: nop.exe
 
 nop.exe: nop.c
-	$(CC) $^ -o $@
+	$(CC) $(CFLAGS) $^ -o $@
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
We defined `CFLAGS`, but didn't use it. The tests don't require change, because (1) our flags just enforce the default behavior, (2) in the relevant test, we double-check that the test binary is non-PIE.