### PR TITLE
Fix v0.6.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.6.0] - 2021-06-28
+
+### Added
+
 - `Error::TraceeDied` variant, `Error::tracee_died()` method to improve error ergonomics
 - x86 `Tracee` methods for reading and writing debug registers
 


### PR DESCRIPTION
Our changelog update in #57 didn't actually finalize the release entry and start a new "Unreleased" section.

Closes #59.