### PR TITLE
Add support for getting/setting registers on aarch64-linux

### DIFF
--- a/src/ptracer.rs
+++ b/src/ptracer.rs
@@ -303,7 +303,6 @@ impl Tracee {
             libc::ptrace(PTRACE_GETREGSET, self.pid, regtype, &mut rv as *mut _ as *mut libc::c_void)
         };
 
-
         nix::errno::Errno::result(res)?;
 
         Ok(unsafe { data.assume_init() })

--- a/src/ptracer.rs
+++ b/src/ptracer.rs
@@ -25,18 +25,18 @@ pub use nix::sys::ptrace::Options;
 /// POSIX signal.
 pub use nix::sys::signal::Signal;
 
-#[cfg(all(target_os = "android", target_arch = "aarch64"))]
+#[cfg(target_arch = "aarch64")]
 const PTRACE_GETREGSET: i32 = 0x4204;
-#[cfg(all(target_os = "android", target_arch = "aarch64"))]
+#[cfg(target_arch = "aarch64")]
 const PTRACE_SETREGSET: i32 = 0x4205;
-#[cfg(all(target_os = "android", target_arch = "aarch64"))]
+#[cfg(target_arch = "aarch64")]
 const NT_PRSTATUS: i32 = 0x1;
-#[cfg(all(target_os = "android", target_arch = "aarch64"))]
+#[cfg(target_arch = "aarch64")]
 const NT_ARM_HW_BREAK: i32 = 0x402;
-#[cfg(all(target_os = "android", target_arch = "aarch64"))]
+#[cfg(target_arch = "aarch64")]
 const NT_ARM_HW_WATCH: i32 = 0x403;
 
-#[cfg(all(target_os = "android", target_arch = "aarch64"))]
+#[cfg(target_arch = "aarch64")]
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub struct user_pt_regs {
@@ -46,7 +46,7 @@ pub struct user_pt_regs {
     pub pstate: u64
 }
 
-#[cfg(all(target_os = "android", target_arch = "aarch64"))]
+#[cfg(target_arch = "aarch64")]
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub struct user_hwdebug_state_reg {
@@ -73,7 +73,7 @@ pub enum DebugRegisterType {
     Watch = NT_ARM_HW_WATCH,
 }
 
-#[cfg(all(target_os = "android", target_arch = "aarch64"))]
+#[cfg(target_arch = "aarch64")]
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub struct user_hwdebug_state {
@@ -82,7 +82,7 @@ pub struct user_hwdebug_state {
     pub dbg_regs: [user_hwdebug_state_reg; 4],
 }
 
-#[cfg(all(target_os = "android", target_arch = "aarch64"))]
+#[cfg(target_arch = "aarch64")]
 #[repr(C)]
 struct regsvec {
     ufb: *mut libc::c_void,
@@ -90,7 +90,7 @@ struct regsvec {
 }
 
 /// Register state of a tracee.
-#[cfg(all(target_os = "android", target_arch = "aarch64"))]
+#[cfg(target_arch = "aarch64")]
 pub type Registers = user_pt_regs;
 
 /// Register state of a tracee.
@@ -188,7 +188,7 @@ impl Tracee {
         Ok(ptrace::getregs(self.pid).died_if_esrch(self.pid)?)
     }
 
-    #[cfg(all(target_os = "android", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     pub fn registers(&self) -> Result<Registers> {
 
         let mut data = std::mem::MaybeUninit::uninit();
@@ -211,7 +211,7 @@ impl Tracee {
         Ok(ptrace::setregs(self.pid, regs).died_if_esrch(self.pid)?)
     }
 
-    #[cfg(all(target_os = "android", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     pub fn set_registers(&mut self, regs: Registers) -> Result<()> {
         let mut rv = regsvec {
             ufb: &regs as *const _ as *const libc::c_void as *mut libc::c_void,
@@ -282,7 +282,7 @@ impl Tracee {
         }
     }
 
-    #[cfg(all(target_os = "android", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     pub fn debug_register(&self, regtype: DebugRegisterType, index: usize) -> Result<user_hwdebug_state_reg> {
         assert!(index < 16);
         let mut data = std::mem::MaybeUninit::uninit();
@@ -312,7 +312,7 @@ impl Tracee {
         }
     }
 
-    #[cfg(all(target_os = "android", target_arch = "aarch64"))]
+    #[cfg(target_arch = "aarch64")]
     pub fn set_debug_register(&self, regtype: DebugRegisterType, index: usize, data: user_hwdebug_state_reg) -> Result<()> {
         assert!(index < 16);
         let mut registers = std::mem::MaybeUninit::uninit();

--- a/src/ptracer.rs
+++ b/src/ptracer.rs
@@ -489,9 +489,6 @@ impl Ptracer {
                 self.remove_tracee(pid);
                 return self.wait();
             },
-            WaitStatus::Stopped(pid, SIGINT) => {
-                Tracee::new(pid, None, Stop::SignalDelivery { signal: SIGINT })
-            },
             WaitStatus::Stopped(pid, SIGTRAP) => {
                 let state = self.tracee_state_mut(pid);
 

--- a/src/ptracer.rs
+++ b/src/ptracer.rs
@@ -44,7 +44,7 @@ const NT_ARM_HW_WATCH: i32 = 0x403;
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub struct user_pt_regs {
-    pub regs: [u64; 31usize],
+    pub regs: [u64; 31],
     pub sp: u64,
     pub pc: u64,
     pub pstate: u64
@@ -53,11 +53,13 @@ pub struct user_pt_regs {
 #[cfg(target_arch = "aarch64")]
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
+// Nested, untagged struct declaration in `user_hwdebug_state`.
 pub struct user_hwdebug_state_reg {
     pub addr: u64,
     pub ctrl: u32,
     pad: u32,
 }
+
 #[cfg(target_arch = "aarch64")]
 impl user_hwdebug_state_reg {
     pub fn new(addr: u64, ctrl: u32) -> Self {

--- a/src/ptracer.rs
+++ b/src/ptracer.rs
@@ -25,10 +25,14 @@ pub use nix::sys::ptrace::Options;
 /// POSIX signal.
 pub use nix::sys::signal::Signal;
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_os = "android", target_arch = "aarch64"))]
 const PTRACE_GETREGSET: i32 = 0x4204;
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(not(target_os = "android"), target_arch = "aarch64"))]
+const PTRACE_GETREGSET: u32 = 0x4204;
+#[cfg(all(target_os = "android", target_arch = "aarch64"))]
 const PTRACE_SETREGSET: i32 = 0x4205;
+#[cfg(all(not(target_os = "android"), target_arch = "aarch64"))]
+const PTRACE_SETREGSET: u32 = 0x4205;
 #[cfg(target_arch = "aarch64")]
 const NT_PRSTATUS: i32 = 0x1;
 #[cfg(target_arch = "aarch64")]


### PR DESCRIPTION
This PR adds support for getting and setting the general-purpose registers on aarch64-linux-android.