### PR TITLE
Update `libc` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ include = [
 ]
 
 [dependencies]
-libc = "0.2.66"
+libc = "0.2.99"
 nix = "0.21.0"
 thiserror = "1.0.11"
 

--- a/src/aarch64.rs
+++ b/src/aarch64.rs
@@ -1,15 +1,3 @@
-#[cfg(all(target_os = "android"))]
-pub(crate) const PTRACE_GETREGSET: i32 = 0x4204;
-
-#[cfg(all(not(target_os = "android")))]
-pub(crate) const PTRACE_GETREGSET: u32 = 0x4204;
-
-#[cfg(all(target_os = "android"))]
-pub(crate) const PTRACE_SETREGSET: i32 = 0x4205;
-
-#[cfg(all(not(target_os = "android")))]
-pub(crate) const PTRACE_SETREGSET: u32 = 0x4205;
-
 /// Defined in [`include/uapi/linux/elf.h`](https://android.googlesource.com/kernel/common/+/refs/heads/android-mainline/include/uapi/linux/elf.h#421).
 const NT_ARM_HW_BREAK: i32 = 0x402;
 const NT_ARM_HW_WATCH: i32 = 0x403;

--- a/src/ptracer.rs
+++ b/src/ptracer.rs
@@ -263,7 +263,7 @@ impl Tracee {
             iov_len: std::mem::size_of::<aarch64::user_hwdebug_state>(),
         };
         let res = unsafe {
-            libc::ptrace(PTRACE_SETREGSET, self.pid, regtype, &mut rv as *mut _ as *mut libc::c_void)
+            libc::ptrace(libc::PTRACE_SETREGSET, self.pid, regtype, &mut rv as *mut _ as *mut libc::c_void)
         };
 
         nix::errno::Errno::result(res)?;

--- a/src/ptracer.rs
+++ b/src/ptracer.rs
@@ -15,7 +15,7 @@ use nix::sys::{
 use crate::error::{Error, Result, ResultExt};
 
 #[cfg(target_arch = "aarch64")]
-use crate::aarch64::{self, PTRACE_GETREGSET, PTRACE_SETREGSET};
+use crate::aarch64;
 
 #[cfg(target_arch = "x86_64")]
 use crate::x86;
@@ -144,7 +144,7 @@ impl Tracee {
         };
 
         let res = unsafe {
-            libc::ptrace(PTRACE_GETREGSET, self.pid, NT_PRSTATUS, &mut rv as *mut _ as *mut libc::c_void)
+            libc::ptrace(libc::PTRACE_GETREGSET, self.pid, NT_PRSTATUS, &mut rv as *mut _ as *mut libc::c_void)
         };
 
         nix::errno::Errno::result(res)?;
@@ -165,7 +165,7 @@ impl Tracee {
         };
 
         let res = unsafe {
-            libc::ptrace(PTRACE_SETREGSET, self.pid, NT_PRSTATUS, &mut rv as *mut _ as *mut libc::c_void)
+            libc::ptrace(libc::PTRACE_SETREGSET, self.pid, NT_PRSTATUS, &mut rv as *mut _ as *mut libc::c_void)
         };
 
         nix::errno::Errno::result(res)?;
@@ -236,7 +236,7 @@ impl Tracee {
             iov_len: std::mem::size_of::<aarch64::user_hwdebug_state>(),
         };
         let res = unsafe {
-            libc::ptrace(PTRACE_GETREGSET, self.pid, regtype, &mut rv as *mut _ as *mut libc::c_void)
+            libc::ptrace(libc::PTRACE_GETREGSET, self.pid, regtype, &mut rv as *mut _ as *mut libc::c_void)
         };
 
         nix::errno::Errno::result(res)?;

--- a/src/ptracer.rs
+++ b/src/ptracer.rs
@@ -46,6 +46,7 @@ pub type Siginfo = libc::siginfo_t;
 const WALL: Option<WaitPidFlag> = Some(WaitPidFlag::__WALL);
 
 /// Linux constant defined in `include/uapi/linux/elf.h`.
+#[cfg(target_arch = "aarch64")]
 const NT_PRSTATUS: i32 = 0x1;
 
 /// A _ptrace-stop_, a tracee state in which it is stopped and ready to accept ptrace


### PR DESCRIPTION
Depend on a newer `libc`, which now provides `PTRACE_GETREGSET` and `PTRACE_SETREGSET` for `android`.