### PR TITLE
Update `nix` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ include = [
 
 [dependencies]
 libc = "0.2.99"
-nix = "0.21.0"
+nix = "0.22.0"
 thiserror = "1.0.11"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]

--- a/src/error.rs
+++ b/src/error.rs
@@ -66,7 +66,7 @@ impl<T> ResultExt<T> for std::result::Result<T, nix::Error> {
         use nix::errno::Errno;
 
         self.map_err(|err| {
-            if let nix::Error::Sys(Errno::ESRCH) = err {
+            if err == Errno::ESRCH {
                 Error::TraceeDied { pid, source: err }
             } else {
                 err.into()


### PR DESCRIPTION
`nix::Error` is now just an alias for `Errno`.