### PR TITLE
Special case SIGINT

### DIFF
--- a/src/ptracer.rs
+++ b/src/ptracer.rs
@@ -428,6 +428,9 @@ impl Ptracer {
                 self.remove_tracee(pid);
                 return self.wait();
             },
+            WaitStatus::Stopped(pid, SIGINT) => {
+                Tracee::new(pid, None, Stop::SignalDelivery { signal: SIGINT })
+            },
             WaitStatus::Stopped(pid, SIGTRAP) => {
                 let state = self.tracee_state_mut(pid);
 


### PR DESCRIPTION
Without this, SIGINTs get swallowed. Not sure why.