### PR TITLE
Bump nix to 0.25.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,20 @@
 [package]
 name = "pete"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Joe Ranweiler <joe@lemma.co>"]
 edition = "2018"
 license = "ISC"
 readme = "README.md"
 repository = "https://github.com/ranweiler/pete"
 description = "A friendly wrapper around ptrace(2)"
+rust-version = "1.56.1"
 include = [
     "src/",
 ]
 
 [dependencies]
 libc = "0.2.99"
-nix = "0.23.0"
+nix = "0.25.0"
 thiserror = "1.0.11"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ A friendly wrapper around the Linux `ptrace(2)` syscall.
 
 ## Requirements
 
-The current minimum supported OS and compiler versions are:
+The current minimum supported OS and compiler versions (MSRV) are:
 
 - Linux 4.8
-- rustc 1.46.0
+- rustc 1.56.1 
 
 Continuous testing is only run for `x86_64-unknown-linux-gnu`.
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,10 +19,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("Could not attach to tracee = {pid}")]
-    Attach {
-        pid: Pid,
-        source: nix::Error,
-    },
+    Attach { pid: Pid, source: nix::Error },
 
     #[error("Tracee died while in ptrace-stop")]
     TraceeDied { pid: Pid, source: nix::Error },
@@ -33,7 +30,9 @@ pub enum Error {
     #[error("OS error")]
     OS(#[from] nix::Error),
 
-    #[error("Internal error: {0}. Please open an issue at https://github.com/ranweiler/pete/issues")]
+    #[error(
+        "Internal error: {0}. Please open an issue at https://github.com/ranweiler/pete/issues"
+    )]
     Internal(String),
 }
 
@@ -49,8 +48,8 @@ impl Error {
 
 macro_rules! internal_error {
     ($ctx: expr) => {
-        return Err($crate::error::Error::Internal($ctx.into()));
-    }
+        return Err($crate::error::Error::Internal($ctx.into()))
+    };
 }
 
 pub(crate) trait ResultExt<T> {


### PR DESCRIPTION
Update the `nix` dependency to 0.25.0 since this is a “major” `0.x` version bump. This also pushes MSRV to 1.56.1 (per nix README), so specify that in the `Cargo.toml`.

Drive-by changes: remove a semi-colon that `rustc` was warning about becoming a hard error in future versions. This also reformatted the file.