### PR TITLE
Update MSRV to 1.56.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.46.0
+          - 1.56.1
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -44,7 +44,7 @@ jobs:
           - aarch64-unknown-linux-gnu
         rust:
           - stable
-          - 1.46.0
+          - 1.56.1
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- MSRV is now 1.56.1
+
 ### Fixed
 
 ## [v0.8.0] - 2021-09-30

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "pete"
 version = "0.8.0"
-authors = ["Joe Ranweiler <joe@lemma.co>"]
+rust-version = "1.56.1"
 edition = "2018"
 license = "ISC"
 readme = "README.md"
+authors = ["Joe Ranweiler <joe@lemma.co>"]
 repository = "https://github.com/ranweiler/pete"
 description = "A friendly wrapper around ptrace(2)"
 include = [

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A friendly wrapper around the Linux `ptrace(2)` syscall.
 The current minimum supported OS and compiler versions are:
 
 - Linux 4.8
-- rustc 1.46.0
+- rustc 1.56.1
 
 Continuous testing is only run for `x86_64-unknown-linux-gnu`.
 


### PR DESCRIPTION
This addresses two issues:
- Broken builds with Rust versions we claim to support (via [`serde`](https://github.com/serde-rs/serde/issues/2255))
- Upcoming [MSRV conflict](https://github.com/nix-rust/nix/pull/1792) in `nix` (h/t @Porges)