### PR TITLE
Expand to block expression in error macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - MSRV is now 1.56.1
+- Fix expansion of internal error macro
 
 ### Fixed
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,9 +48,9 @@ impl Error {
 }
 
 macro_rules! internal_error {
-    ($ctx: expr) => {
+    ($ctx: expr) => {{
         return Err($crate::error::Error::Internal($ctx.into()));
-    }
+    }}
 }
 
 pub(crate) trait ResultExt<T> {


### PR DESCRIPTION
We intended `internal_error!()` to expand to a block expression enclosing an early return. It _actually_ expands to `return Err(..)`, as an expression. All of our use sites work as-is, but the non-block version will eventually become a [hard error](https://github.com/rust-lang/rust/issues/79813) due to our use of a semicolon. Fix the offending macro body.