### PR TITLE
Bump nix requirement to 0.26, memoffset to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ include = [
 
 [dependencies]
 libc = "0.2.99"
-nix = "0.25.0"
+nix = "0.26"
 thiserror = "1.0.11"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ nix = "0.26"
 thiserror = "1.0.11"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
-memoffset = "0.6.4"
+memoffset = "0.7.1"
 
 [dev-dependencies]
 anyhow = "1.0.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ nix = "0.26"
 thiserror = "1.0.11"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
-memoffset = "0.7.1"
+memoffset = "0.8"
 
 [dev-dependencies]
 anyhow = "1.0.31"


### PR DESCRIPTION
Bump to latest version, to allow use of latest `nix` with `pete`.

Bump `memoffset` to match that used by `nix`.