### PR TITLE
Fix integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: install OS tools
-        run: sudo apt install -y binutils
       - name: build test-programs
         run: cd test-programs && ./build-all.sh
       - name: upload test-programs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: install OS tools
+        run: sudo apt install -y binutils
       - name: build test-programs
         run: cd test-programs && ./build-all.sh
       - name: upload test-programs

--- a/script/hw-breakpoint-test
+++ b/script/hw-breakpoint-test
@@ -9,11 +9,10 @@ do_test() {
     EXE=$(readlink -f $1)
 
     # Ensure $EXE is non-position independent, so the entry point is an absolute VA.
-    FILE_HEADER=$(readelf -h $EXE)
-    echo $FILE_HEADER | grep -iv 'Type:.*DYN.*Position-Independent Executable file'
+    readelf -h $EXE | grep -iv 'Type:.*DYN.*Position-Independent Executable file'
 
     # Get the entry point of $EXE, as a VA in the format `0x%x`.
-    EA=$(echo $FILE_HEADER | grep Entry | grep -Eo '0x.+$' | tr -d ' ')
+    EA=$(readelf -h $EXE | grep Entry | grep -Eo '0x.+$' | tr -d ' ')
 
     OUTPUT=$($HW_BREAK_EX -q -b $EA -- $EXE)
 

--- a/script/hw-breakpoint-test
+++ b/script/hw-breakpoint-test
@@ -9,7 +9,9 @@ do_test() {
     EXE=$(readlink -f $1)
 
     # Ensure $EXE is non-position independent, so the entry point is an absolute VA.
-    file $EXE | grep -iv 'pie executable'
+    FILEINFO=$(file $EXE)
+
+    echo $FILEINFO | grep -iv 'pie executable'
 
     which readelf
 

--- a/script/hw-breakpoint-test
+++ b/script/hw-breakpoint-test
@@ -9,10 +9,8 @@ do_test() {
     EXE=$(readlink -f $1)
 
     # Ensure $EXE is non-position independent, so the entry point is an absolute VA.
-    FILE_INFO=$(file $EXE)
-    (echo $FILE_INFO | grep -iv 'pie executable') || echo "error: $1 compiled as PIE"
-
     FILE_HEADER=$(readelf -h $EXE)
+    (echo $FILE_HEADER | grep -iv 'Type:.*DYN.*Position-Independent Executable file') | echo "error: $1 compiled as PIE"
 
     # Get the entry point of $EXE, as a VA in the format `0x%x`.
     EA=$(echo $FILE_HEADER | grep Entry | grep -Eo '0x.+$' | tr -d ' ')

--- a/script/hw-breakpoint-test
+++ b/script/hw-breakpoint-test
@@ -10,7 +10,7 @@ do_test() {
 
     # Ensure $EXE is non-position independent, so the entry point is an absolute VA.
     FILE_HEADER=$(readelf -h $EXE)
-    (echo $FILE_HEADER | grep -iv 'Type:.*DYN.*Position-Independent Executable file') | echo "error: $1 compiled as PIE"
+    echo $FILE_HEADER | grep -iv 'Type:.*DYN.*Position-Independent Executable file'
 
     # Get the entry point of $EXE, as a VA in the format `0x%x`.
     EA=$(echo $FILE_HEADER | grep Entry | grep -Eo '0x.+$' | tr -d ' ')

--- a/script/hw-breakpoint-test
+++ b/script/hw-breakpoint-test
@@ -11,6 +11,8 @@ do_test() {
     # Ensure $EXE is non-position independent, so the entry point is an absolute VA.
     file $EXE | grep -iv 'pie executable'
 
+    which readelf
+
     # Get the entry point of $EXE, as a VA in the format `0x%x`.
     EA=$(readelf -h $EXE | grep Entry | grep -Eo '0x.+$' | tr -d ' ')
 

--- a/script/hw-breakpoint-test
+++ b/script/hw-breakpoint-test
@@ -11,7 +11,7 @@ do_test() {
     # Ensure $EXE is non-position independent, so the entry point is an absolute VA.
     FILEINFO=$(file $EXE)
 
-    echo $FILEINFO | grep -iv 'pie executable'
+    (echo $FILEINFO | grep -iv 'pie executable') || echo "error: $1 compiled as PIE"
 
     which readelf
 

--- a/script/hw-breakpoint-test
+++ b/script/hw-breakpoint-test
@@ -8,6 +8,8 @@ HW_BREAK_EX="${BUILD_ROOT}/release/examples/hw_break"
 do_test() {
     EXE=$(readlink -f $1)
 
+    readelf -h $EXE
+
     # Ensure $EXE is non-position independent, so the entry point is an absolute VA.
     readelf -h $EXE | grep -iv 'Type:.*DYN.*Position-Independent Executable file'
 

--- a/script/hw-breakpoint-test
+++ b/script/hw-breakpoint-test
@@ -9,14 +9,13 @@ do_test() {
     EXE=$(readlink -f $1)
 
     # Ensure $EXE is non-position independent, so the entry point is an absolute VA.
-    FILEINFO=$(file $EXE)
+    FILE_INFO=$(file $EXE)
+    (echo $FILE_INFO | grep -iv 'pie executable') || echo "error: $1 compiled as PIE"
 
-    (echo $FILEINFO | grep -iv 'pie executable') || echo "error: $1 compiled as PIE"
-
-    which readelf
+    FILE_HEADER=$(readelf -h $EXE)
 
     # Get the entry point of $EXE, as a VA in the format `0x%x`.
-    EA=$(readelf -h $EXE | grep Entry | grep -Eo '0x.+$' | tr -d ' ')
+    EA=$(echo $FILE_HEADER | grep Entry | grep -Eo '0x.+$' | tr -d ' ')
 
     OUTPUT=$($HW_BREAK_EX -q -b $EA -- $EXE)
 

--- a/test-programs/nop/Makefile
+++ b/test-programs/nop/Makefile
@@ -1,5 +1,5 @@
 CC = clang-14
-CFLAGS = -fno-pie
+CFLAGS = -no-pie
 
 all: nop.exe
 

--- a/test-programs/nop/Makefile
+++ b/test-programs/nop/Makefile
@@ -1,4 +1,4 @@
-CC = clang-11
+CC = clang-14
 CFLAGS = -fno-pie
 
 all: nop.exe


### PR DESCRIPTION
Update the clang version expected in integration tests. The runner images we're using no longer ship `clang-11.` Also update the Makefile for the test program to override new runner defaults re PIE compilation.