### PR TITLE
Add default options accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add accessors for the default options applied to newly-spawned tracees
+
 ### Changed
 
 - Update MSRV to 1.64

--- a/src/ptracer.rs
+++ b/src/ptracer.rs
@@ -351,6 +351,16 @@ impl Ptracer {
         Self { options, tracees }
     }
 
+    /// Returns a reference to the default ptrace options applied to newly-spawned tracees.
+    pub fn default_options(&self) -> &Options {
+        &self.options
+    }
+
+    /// Returns a mutable reference to the default ptrace options applied to newly-spawned tracees.
+    pub fn default_options_mut(&mut self) -> &mut Options {
+        &mut self.options
+    }
+
     /// Resume the stopped tracee, delivering any pending signal.
     pub fn restart(&mut self, tracee: Tracee, restart: Restart) -> Result<()> {
         let Tracee { pid, pending, .. } = tracee;


### PR DESCRIPTION
Enable reading and modifying the default `Options` applied to newly-spawned tracees.

Closes #96.