### PR TITLE
Update MSRV to 1.64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.63
+          - 1.64
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -44,7 +44,7 @@ jobs:
           - aarch64-unknown-linux-gnu
         rust:
           - stable
-          - 1.63
+          - 1.64
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update MSRV to 1.64
+
 ### Fixed
 
 ## [v0.10.0] - 2023-04-20

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pete"
 version = "0.10.0"
-rust-version = "1.63"
+rust-version = "1.64"
 edition = "2018"
 license = "ISC"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A friendly wrapper around the Linux `ptrace(2)` syscall.
 The current minimum supported OS and compiler versions are:
 
 - Linux 4.8
-- rustc 1.63
+- rustc 1.64
 
 Continuous testing is only run for `x86_64-unknown-linux-gnu`.
 


### PR DESCRIPTION
A transitive dependency of `ntest` has an MSRV of 1.64, which breaks the current test build. That's only a few months newer than our current MSRV, so adopt that.