### PR TITLE
Only poll known tracees with `wait(2)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add accessors for `wait()` poll delay
+
 ### Changed
 
 ### Fixed
+
+- Only poll known tracees for `wait(2)` status changes
 
 ## [v0.11.0] - 2023-09-04
 

--- a/tests/tracee_died.rs
+++ b/tests/tracee_died.rs
@@ -17,7 +17,7 @@ macro_rules! assert_matches {
 
 #[cfg(target_arch = "x86_64")]
 #[test]
-#[timeout(100)]
+#[timeout(1000)]
 fn test_tracee_died() -> Result<()> {
     let cmd = Command::new("true");
 

--- a/tests/wait_untraced_child.rs
+++ b/tests/wait_untraced_child.rs
@@ -1,0 +1,41 @@
+use std::process::Command;
+
+use anyhow::Result;
+use ntest::timeout;
+use pete::{Ptracer, Restart};
+
+#[test]
+#[timeout(5000)]
+fn test_wait_untraced_child() -> Result<()> {
+    // Untraced, exits before tracee.
+    let mut fast = Command::new("sleep").arg("0.1").spawn()?;
+
+    // Untraced, exits after tracee.
+    let mut slow = Command::new("sleep").arg("2").spawn()?;
+
+    // Traced.
+    let mut traceme = Command::new("sleep");
+    traceme.arg("1");
+
+    let mut tracer = Ptracer::new();
+    let mut tracee = tracer.spawn(traceme)?;
+
+    while let Some(tracee) = tracer.wait()? {
+        eprintln!("{}: {:?}", tracee.pid, tracee.stop);
+
+        tracer.restart(tracee, Restart::Continue)?;
+    }
+
+    eprintln!("waiting on tracee: {}", tracee.id());
+    println!("tracee status: {}", tracee.wait()?);
+
+    eprintln!("waiting on fast: {}", fast.id());
+    println!("fast status: {}", fast.wait()?);
+
+    eprintln!("waiting on slow: {}", slow.id());
+    println!("slow status: {}", slow.wait()?);
+
+    eprintln!("ok!");
+
+    Ok(())
+}


### PR DESCRIPTION
- Only poll known tracee PIDs with `wait(2)` to avoid breaking `std::process::Child::wait()`
- Poll tracees with `WNOHANG`, apply cool-off poll delay if no new statuses
- Add accessors to allow tuning poll delay, default to 100ms
- Add test case

Closes #100.