### PR TITLE
Use process groups to avoid delay-loops when waiting for child PIDs

### DIFF
--- a/tests/tracee_died.rs
+++ b/tests/tracee_died.rs
@@ -10,14 +10,18 @@ macro_rules! assert_matches {
         if let $pat = $expr {
             // Pass.
         } else {
-            panic!("expected `{}` to match `{}`", stringify!($expr), stringify!($pat));
+            panic!(
+                "expected `{}` to match `{}`",
+                stringify!($expr),
+                stringify!($pat)
+            );
         }
-    }
+    };
 }
 
 #[cfg(target_arch = "x86_64")]
 #[test]
-#[timeout(1000)]
+#[timeout(100)]
 fn test_tracee_died() -> Result<()> {
     let cmd = Command::new("true");
 


### PR DESCRIPTION
This is a bit of a proof-of-concept that it works:

1. invoke `setsid` in pre-exec when spawning a new process
2. when waiting for a process, wait for its `pgid` instead of `pid`

The loop inside `wait_for_tracees` is a bit of a lie, really we expect there to be one `pgid` so we are only ever going to visit the first tracee and get the `pgid` there, but doing it this way involved less code churn.

This assumes that no tracee is going to mess with its own process group. If they do, then we'd need to go back to a loop over multiple process groups like before… perhaps:

1. collect PGs of all tracees
2. if there's just one, block on it
3. otherwise fall back to the existing loop

(Apologies for the messy diff but it got rustfmt'd.)