### PR TITLE
Simplify poll backoff

### DIFF
--- a/src/ptracer.rs
+++ b/src/ptracer.rs
@@ -349,7 +349,7 @@ pub struct Ptracer {
     tracees: BTreeMap<i32, State>,
 }
 
-const DEFAULT_POLL_DELAY: Duration = Duration::from_millis(0);
+const DEFAULT_POLL_DELAY: Duration = Duration::from_micros(1);
 
 impl Ptracer {
     pub fn new() -> Self {
@@ -484,7 +484,7 @@ impl Ptracer {
                 std::thread::sleep(poll_delay);
 
                 // Back off before next attempt.
-                poll_delay = (2 * poll_delay) + Duration::from_micros(1);
+                poll_delay *= 2;
             }
         };
 


### PR DESCRIPTION
The poll delay is never used until the first empty poll, so we'd prefer it to be nonzero. Initialize it to 1 us and then just double when backing off.