### PR TITLE
Detach from exiting tracees

### DIFF
--- a/tests/child_exit_status.rs
+++ b/tests/child_exit_status.rs
@@ -1,0 +1,31 @@
+use std::process::Command;
+
+use anyhow::Result;
+use ntest::timeout;
+use pete::{Ptracer, Restart};
+
+#[test]
+#[timeout(2000)]
+fn test_trace_true() -> Result<()> {
+    let cmd = Command::new("true");
+    let mut tracer = Ptracer::new();
+    let mut tracee = tracer.spawn(cmd)?;
+
+    while let Some(tracee) = tracer.wait()? {
+        eprintln!("{}: {:?}", tracee.pid, tracee.stop);
+
+        tracer.restart(tracee, Restart::Continue)?;
+    }
+
+    eprintln!("waiting on tracee: {}", tracee.id());
+
+    let status = tracee.wait()?;
+    eprintln!("tracee status: {status}");
+
+    assert!(status.success());
+    assert_eq!(status.code(), Some(0));
+
+    eprintln!("ok!");
+
+    Ok(())
+}

--- a/tests/tracee_wait_child.rs
+++ b/tests/tracee_wait_child.rs
@@ -1,0 +1,29 @@
+use std::process::Command;
+
+use anyhow::Result;
+use ntest::timeout;
+use pete::{Ptracer, Restart};
+
+#[test]
+#[timeout(2000)]
+fn test_waiting_child() -> Result<()> {
+    let mut cmd = Command::new("/bin/bash");
+    cmd.args(&["-c", "sleep 1; wait; echo ok!"]);
+
+    let mut tracer = Ptracer::new();
+    let mut tracee = tracer.spawn(cmd)?;
+    eprintln!("tracee pid = {}", tracee.id());
+
+    while let Some(tracee) = tracer.wait()? {
+        eprintln!("{}: {:?}", tracee.pid, tracee.stop);
+
+        tracer.restart(tracee, Restart::Continue)?;
+    }
+
+    eprintln!("waiting on tracee: {}", tracee.id());
+    eprintln!("tracee status: {}", tracee.wait()?);
+
+    eprintln!("ok!");
+
+    Ok(())
+}

--- a/tests/wait_untraced_child.rs
+++ b/tests/wait_untraced_child.rs
@@ -27,13 +27,13 @@ fn test_wait_untraced_child() -> Result<()> {
     }
 
     eprintln!("waiting on tracee: {}", tracee.id());
-    println!("tracee status: {}", tracee.wait()?);
+    eprintln!("tracee status: {}", tracee.wait()?);
 
     eprintln!("waiting on fast: {}", fast.id());
-    println!("fast status: {}", fast.wait()?);
+    eprintln!("fast status: {}", fast.wait()?);
 
     eprintln!("waiting on slow: {}", slow.id());
-    println!("slow status: {}", slow.wait()?);
+    eprintln!("slow status: {}", slow.wait()?);
 
     eprintln!("ok!");
 


### PR DESCRIPTION
Detach from tracees upon restart when we observe `PTRACE_EVENT_EXIT`. This allows tracer-external `wait()` calls to behave as expected.

Add tests for 2 critical cases:
- Post-detach behavior of `std::process::Child::wait()`, in the same process as the tracer
- Tracee calls to `wait()` on formerly-traced, exiting grandchildren of the tracer process

Closes #119.