### PR TITLE
Add event trace test assertions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,9 @@ memoffset = "0.9.1"
 anyhow = "1.0.31"
 lazy_static = "1.4.0"
 ntest = "0.9.0"
+pretty_assertions = "1.4.1"
 structopt = "0.3.21"
 tracing-subscriber = "0.3.19"
+
+[profile.release]
+debug = 1

--- a/tests/child_exit_status.rs
+++ b/tests/child_exit_status.rs
@@ -10,7 +10,7 @@ use support::*;
 
 #[test]
 #[timeout(2000)]
-fn test_trace_true() -> Result<()> {
+fn test_trace_child_exit_status() -> Result<()> {
     let cmd = Command::new("true");
     let mut tracer = Ptracer::new();
     let mut tracee = tracer.spawn(cmd)?;

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -29,6 +29,7 @@ macro_rules! event {
     }};
 }
 
+/// Assert that two event traces are equivalent modulo PID normalization.
 pub fn assert_equivalent(left: &[Tracee], right: &[Tracee]) {
     let normed_left = Normalizer::normalize(left);
     let normed_right = Normalizer::normalize(right);

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,0 +1,110 @@
+use std::{collections::HashMap, convert::TryInto};
+
+use pete::{Pid, Stop, Tracee};
+use pretty_assertions::assert_eq;
+
+#[allow(unused)]
+macro_rules! pid {
+    ($raw: expr) => {
+        pete::Pid::from_raw($raw)
+    };
+}
+
+macro_rules! event {
+    ($raw_pid: expr, $stop: expr) => {{
+        use pete::Stop::*;
+
+        let pid = pete::Pid::from_raw($raw_pid);
+
+        pete::Tracee::new(pid, None, $stop)
+    }};
+    ($raw_pid: expr, $stop: expr, $signal: expr) => {{
+        use pete::Signal::*;
+        use pete::Stop::*;
+
+        let pid = pete::Pid::from_raw($raw_pid);
+
+        pete::Tracee::new(pid, $signal, $stop)
+    }};
+}
+
+pub fn assert_equivalent(left: &[Tracee], right: &[Tracee]) {
+    let normed_left = Normalizer::normalize(left);
+    let normed_right = Normalizer::normalize(right);
+    assert_eq!(normed_left, normed_right)
+}
+
+/// Normalizes an event trace by substituting each concrete raw PID value with one that
+/// matches its ordinal of appearance in the trace.
+#[derive(Default)]
+struct Normalizer {
+    map: HashMap<Pid, Pid>,
+}
+
+impl Normalizer {
+    pub fn normalize(trace: &[Tracee]) -> Vec<Tracee> {
+        Normalizer::default().normalize_trace(trace)
+    }
+
+    fn normalize_trace(&mut self, trace: &[Tracee]) -> Vec<Tracee> {
+        let mut normed_trace = vec![];
+
+        for tracee in trace {
+            let normed = self.normalize_tracee(tracee);
+            normed_trace.push(normed);
+        }
+
+        normed_trace
+    }
+
+    fn normalize_tracee(&mut self, tracee: &Tracee) -> Tracee {
+        let normed_pid = self.normalize_pid(tracee.pid);
+        let normed_stop = self.normalize_stop(tracee.stop);
+        Tracee::new(normed_pid, tracee.pending, normed_stop)
+    }
+
+    fn normalize_stop(&mut self, stop: Stop) -> Stop {
+        match stop {
+            Stop::Attach => stop,
+            Stop::SignalDelivery { signal: _ } => stop,
+            Stop::Group { signal: _ } => stop,
+            Stop::SyscallEnter => stop,
+            Stop::SyscallExit => stop,
+            Stop::Clone { new } =>  {
+                let normed_new = self.normalize_pid(new);
+                Stop::Clone { new: normed_new }
+            },
+            Stop::Fork { new } => {
+                let normed_new = self.normalize_pid(new);
+                Stop::Fork { new: normed_new }
+            },
+            Stop::Exec { old } => {
+                let normed_old = self.normalize_pid(old);
+                Stop::Exec { old: normed_old }
+            },
+            Stop::Exiting { exit_code: _ } => stop,
+            Stop::Signaling { signal: _, core_dumped: _ } => stop,
+            Stop::Vfork { new } => {
+                let normed_new = self.normalize_pid(new);
+                Stop::Vfork { new: normed_new }
+            },
+            Stop::VforkDone { new } => {
+                let normed_new = self.normalize_pid(new);
+                Stop::VforkDone { new: normed_new }
+            },
+            Stop::Seccomp { data: _ } => stop,
+        }
+    }
+
+    fn normalize_pid(&mut self, pid: Pid) -> Pid {
+        // Avoid borrowck error in `default` fn.
+        let next_free = self.map.len();
+
+        let entry = self.map.entry(pid).or_insert_with(|| {
+            let raw: i32 = next_free.try_into().expect("exhausted free test PIDs");
+            Pid::from_raw(raw)
+        });
+
+        *entry
+    }
+}

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashMap, convert::TryInto};
+use std::collections::HashMap;
+use std::convert::TryInto;
 
 use pete::{Pid, Stop, Tracee};
 use pretty_assertions::assert_eq;

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -11,6 +11,7 @@ macro_rules! pid {
     };
 }
 
+/// Construct a tracee stop event with a readable, integration test-friendly syntax.
 macro_rules! event {
     ($raw_pid: expr, $stop: expr) => {{
         use pete::Stop::*;

--- a/tests/tracee_died.rs
+++ b/tests/tracee_died.rs
@@ -8,17 +8,6 @@ use pete::{Error, Ptracer, Restart, Signal};
 mod support;
 use support::*;
 
-// Support absence of `matches!()` in rustc 1.41.0.
-macro_rules! assert_matches {
-    ($expr: expr, $pat: pat) => {
-        if let $pat = $expr {
-            // Pass.
-        } else {
-            panic!("expected `{}` to match `{}`", stringify!($expr), stringify!($pat));
-        }
-    }
-}
-
 #[cfg(target_arch = "x86_64")]
 #[test]
 #[timeout(100)]
@@ -39,7 +28,7 @@ fn test_tracee_died() -> Result<()> {
         child.kill()?;
 
         if let Err(err) = tracer.restart(tracee, Restart::Continue) {
-            assert_matches!(err, Error::TraceeDied { .. });
+            assert!(matches!(err, Error::TraceeDied { .. }));
             assert!(err.tracee_died());
 
             let regs = tracee.registers();
@@ -47,7 +36,7 @@ fn test_tracee_died() -> Result<()> {
             assert!(regs.is_err());
 
             if let Err(err) = regs {
-                assert_matches!(err, Error::TraceeDied { .. });
+                assert!(matches!(err, Error::TraceeDied { .. }));
                 assert!(err.tracee_died());
             } else {
                 unreachable!();

--- a/tests/tracee_wait_child.rs
+++ b/tests/tracee_wait_child.rs
@@ -2,7 +2,11 @@ use std::process::Command;
 
 use anyhow::Result;
 use ntest::timeout;
-use pete::{Ptracer, Restart};
+use pete::{Ptracer, Restart, Signal};
+
+#[macro_use]
+mod support;
+use support::*;
 
 #[test]
 #[timeout(2000)]
@@ -14,11 +18,24 @@ fn test_waiting_child() -> Result<()> {
     let mut tracee = tracer.spawn(cmd)?;
     eprintln!("tracee pid = {}", tracee.id());
 
+    let mut events = vec![];
+
     while let Some(tracee) = tracer.wait()? {
         eprintln!("{}: {:?}", tracee.pid, tracee.stop);
+        events.push(tracee);
 
         tracer.restart(tracee, Restart::Continue)?;
     }
+
+    assert_equivalent(&events, &[
+        event!(0, SyscallExit),
+        event!(0, Fork { new: pid!(1) }, SIGTRAP),
+        event!(1, Attach),
+        event!(1, Exec { old: pid!(1) }, SIGTRAP),
+        event!(1, Exiting { exit_code: 0}, SIGTRAP),
+        event!(0, SignalDelivery { signal: Signal::SIGCHLD }, SIGCHLD),
+        event!(0, Exiting { exit_code: 0 }, SIGTRAP)
+    ]);
 
     eprintln!("waiting on tracee: {}", tracee.id());
     eprintln!("tracee status: {}", tracee.wait()?);


### PR DESCRIPTION
- Add an `assert_equivalent()` test helper, which tests trace equivalence modulo PID normalization
- Implement an event trace normalizer, which converts a trace into a representative with normalized PIDs
- Update existing integration tests to check for expected event traces (in addition to existing assertions)
- Remove a vestigial polyfill that was only needed for now-unsupported `rustc` versions